### PR TITLE
Updated route to expect apiPlaceId key instead of placeId key

### DIFF
--- a/app/itinerary/routes.py
+++ b/app/itinerary/routes.py
@@ -135,7 +135,7 @@ def add_one_place(trip_id):
 
     local_id = place['id']
     place_name = place['placeName']
-    geoapify_placeId = place['placeId']
+    geoapify_placeId = place['apiPlaceId']
     place_address = place['address']
     place_img = place['imgURL']
     favorite = place['favorite']

--- a/app/places/routes.py
+++ b/app/places/routes.py
@@ -308,7 +308,7 @@ def add_get_place(trip_id):
 
     local_id = place['id']
     place_name = place['placeName']
-    geoapify_placeId = place['placeId']
+    geoapify_placeId = place['apiPlaceId']
     place_address = place['address']
     place_img = place['imgURL']
     category = place.get('category', None)


### PR DESCRIPTION
### Updated 2 routes:

- places/add-get-place/<trip_id>
- itinerary/add-one-place/<trip_id>

Updated each route to expect `apiPlaceId` instead of `placeId` key for the google place Id value stored on place objects
![old route](https://github.com/user-attachments/assets/247c87d3-0ec8-42ad-95d0-53266c114f4c)
![new route](https://github.com/user-attachments/assets/0c6379c6-9874-4e9b-ade7-55a3e74f8b50)
 (see images)